### PR TITLE
Fix code scanning alert no. 14: Database query built from user-controlled sources

### DIFF
--- a/controllers/authentication/authService.js
+++ b/controllers/authentication/authService.js
@@ -35,7 +35,7 @@ exports.savePasswordResetToken = async (userId, token) => {
 
 exports.verifyPasswordResetToken = async (token) => {
     const user = await User.findOne({
-      resetPasswordToken: token,
+      resetPasswordToken: { $eq: token },
       resetPasswordExpires: { $gt: Date.now() },
     });
     if (user) {


### PR DESCRIPTION
Fixes [https://github.com/mosetf/RAQA/security/code-scanning/14](https://github.com/mosetf/RAQA/security/code-scanning/14)

To fix the problem, we need to ensure that the `token` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the user input is interpreted as a literal value and not as a query object. This approach prevents NoSQL injection attacks by making sure that the input is not executed as part of the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
