### PR TITLE
Fix code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/controllers/authentication/authController.js
+++ b/controllers/authentication/authController.js
@@ -1,4 +1,5 @@
 const authService = require('./authService');
+const validator = require('validator');
 const logger = require('../../utils/logger');
 const bcrypt = require('bcrypt');
 const User = require('../../models/User');
@@ -41,8 +42,12 @@ exports.login = async (req, res) => {
 
 exports.forgotPassword = async (req, res) => {
     const { email } = req.body;
+    if (!validator.isEmail(email)) {
+      logger.error('Invalid email format: ' + email);
+      return res.status(400).send({ error: 'Invalid email format' });
+    }
     try {
-      await authService.forgotPassword(req.body.email);
+      await authService.forgotPassword(email);
       res.status(200).send({ message: 'Password reset link sent' });
     } catch (error) {
       logger.error('Forgot password failed: ' + error.message);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "nodemailer-express-handlebars": "^6.1.2",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "winston": "^3.13.1"
+    "winston": "^3.13.1",
+    "validator": "^13.12.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
Fixes [https://github.com/mosetf/RAQA/security/code-scanning/13](https://github.com/mosetf/RAQA/security/code-scanning/13)

To fix the problem, we need to ensure that the `email` parameter is sanitized before being used in the MongoDB query. We can achieve this by validating that the `email` is a string and matches a typical email format. This can be done using a regular expression or a validation library like `validator`.

1. Add the `validator` library to validate the email format.
2. Validate the `email` parameter in the `forgotPassword` function in `controllers/authentication/authController.js` before passing it to the `authService.forgotPassword` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
