### PR TITLE
Fix code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "winston": "^3.13.1",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const routes = require('./routes/routes');
 const passport = require('./config/passport');
 const connectDB = require('./config/db');
 const logger = require('./utils/logger');
+const RateLimit = require('express-rate-limit');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -45,8 +46,14 @@ app.get('/api/quote', async (req, res) => {
 // API routes
 app.use('/api', routes);
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
 // Serve the React app for all other routes
-app.get('*', (req, res) => {
+app.get('*', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
 });
 


### PR DESCRIPTION
Fixes [https://github.com/mosetf/RAQA/security/code-scanning/15](https://github.com/mosetf/RAQA/security/code-scanning/15)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
3. Apply the rate limiter to the route that serves the React app (`app.get('*', ...)`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
