### PR TITLE
Fix code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/controllers/authentication/authService.js
+++ b/controllers/authentication/authService.js
@@ -17,7 +17,7 @@ exports.logout = (req) => {
 };
 
 exports.findUserByEmail = async (email) => {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     logger.info(`User found by email: ${email}`); // Log user found
     return user;
 };


### PR DESCRIPTION
Fixes [https://github.com/mosetf/RAQA/security/code-scanning/13](https://github.com/mosetf/RAQA/security/code-scanning/13)

To fix the problem, we need to ensure that the user-provided `email` parameter is safely embedded into the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the `email` is treated as a literal value and not as a query object. This approach prevents any potential NoSQL injection attacks.

**Steps to fix:**
1. Modify the `findUserByEmail` function in `controllers/authentication/authService.js` to use the `$eq` operator for the `email` field in the MongoDB query.


