### PR TITLE
Fix code scanning alert no. 6: Clear text transmission of sensitive cookie

### DIFF
--- a/tests/authRoutes.test.js
+++ b/tests/authRoutes.test.js
@@ -15,7 +15,8 @@ app.use(session({
     secret: 'your_secret_key',
     resave: false,
     saveUninitialized: false,
-    store: MongoStore.create({ mongoUrl: process.env.MONGO_URL })
+    store: MongoStore.create({ mongoUrl: process.env.MONGO_URL }),
+    cookie: { secure: true, httpOnly: true }
 }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Fixes [https://github.com/mosetf/RAQA/security/code-scanning/6](https://github.com/mosetf/RAQA/security/code-scanning/6)

To fix the problem, we need to ensure that the session cookie is only transmitted over HTTPS by setting the `secure` attribute to `true`. This can be done by modifying the session configuration to include the `cookie` option with the `secure` attribute set to `true`. Additionally, we should set the `httpOnly` attribute to `true` to prevent client-side scripts from accessing the cookie, enhancing security.

- Modify the session configuration in the `tests/authRoutes.test.js` file.
- Add the `cookie` option with `secure: true` and `httpOnly: true` to the session configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
